### PR TITLE
Collating ideas from the meeting 5/31/2022 Meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 The ICRC-1 is a standard for Fungible Tokens on the [Internet Computer](https://internetcomputer.org).
 
+## Data structures
+
+```
+
+type TransactionResponse = {
+  #ok : { //index confirmed
+   #index: nat64;
+   #hash : Blob; //to allow for hash blobs
+  }; 
+  #err: TransactionError;
+  #pending: Blob; //hash if pending
+  #noop; //to support "free" operations
+
+```
+
 ## Methods
 
 ### name
@@ -9,7 +24,7 @@ The ICRC-1 is a standard for Fungible Tokens on the [Internet Computer](https://
 Returns the name of the token, e.g. `MyToken`.
 
 ```
-name_icrc: () -> (text) query;
+name_ic1: () -> (text) query;
 ```
 
 ### symbol
@@ -17,7 +32,7 @@ name_icrc: () -> (text) query;
 Returns the symbol of the token, e.g. `ICP`.
 
 ```
-symbol_icrc: () -> (text) query;
+symbol_ic1: () -> (text) query;
 ```
 
 ### decimals
@@ -25,7 +40,7 @@ symbol_icrc: () -> (text) query;
 Returns the number of decimals the token uses, e.g. `8`, means to divide the token amount by `100000000` to get its user representation.
 
 ```
-decimals_icrc: () -> (nat32) query;
+decimals_ic1: () -> (nat32) query;
 ```
 
 ### totalSupply
@@ -33,7 +48,7 @@ decimals_icrc: () -> (nat32) query;
 Returns the total token supply.
 
 ```
-totalSupply_icrc: () -> (nat64) query;
+totalSupply_ic1: () -> (nat64) query;
 ```
 
 ### balanceOf
@@ -41,7 +56,7 @@ totalSupply_icrc: () -> (nat64) query;
 Returns the balance of the account given as argument.
 
 ```
-balanceOf_icrc: (record { Principal; SubAccount; }) -> (nat64) query;
+balanceOf_ic1: (record { Principal; SubAccount; }) -> (nat64) query;
 ```
 
 ### transfer
@@ -54,20 +69,17 @@ type TransferArgs = record {
     to_principal: Principal;
     to_subaccount: opt SubAccount;
     amount: nat64;
-    callback: opt CallbackArgs;
+    callback: opt Principal;  //what if someone puts a user principal here?  Does the IC know not to call it?
     memo: nat32;
     fee: nat64;
+    timestamp: int;
 };
 
-type CallbackArgs = record {
-    canister: Principal;
-    method: Text;
-};
 
-transfer_icrc: (TransferArgs) -> (variant { Ok: nat64; Err: TransferError; });
+transfer_icrc: (TransferArgs) -> TransactionResponse;
 ```
 
-The result is either the block index of the transfer or an error. The list of errors is:
+The result is either the block index or hash of the transfer, a pending hash, a noop, or an error. The list of errors is:
 
 ```
 type TransferError = variant {
@@ -79,5 +91,62 @@ type TransferError = variant {
 The canister refrenced in the callback should implement the following signature:
 
 ```
-    transfer_notified_icrc : (BlockArgs) -> () //one shot
+    transfer_notified_ic1 : (BlockArgs) -> () //one shot call
+```
+
+### Re-notify
+
+Asks a ledger to re-notify of a transactions. Returns the index for any fee charged. Fee is optional at the discression of the ledger.
+
+Renotify will call the ame transfer_notified_ic1 endpoint as a regular transfer.
+
+Note: With archive nodes this cold get tricky and slow.
+
+```
+type NotifyArgs = record {
+    index: nat64;               // Block Desirred
+    subaccount: opt SubAccount. // Sub account to charge the fee from
+    fee: nat64;                 // fee willing to pay
+};
+
+renotify_ic1: (NotifyArgs) -> TransactionResponse;
+```
+
+
+### Approval Flow
+
+Allows a user to approve a canister to transfer funds from their account.
+
+#### approve
+
+Approves the to spend account to pull tokens. They should be moved from the to/default sub account to a specific sub account indicated by 32 Byte hash of 'ic1-approve//' + ToPrincipal (perhaps not very private?) to prevent double spend/reentrance attacks.
+
+```
+type ApproveArgs = record {
+    to: principal;                   // User approved to spend
+    to_subaccount: opt SubAccount    // Sub account to send the tokens to; If sub account is null the to address canmove to any sub account
+    from_subaccount: opt SubAccount. // sub account to pull tokens from; If sub account is null use the default account
+    amount: nat64;
+    fee: nat64;                      // fee willing to pay for the approve
+};
+
+approve_ic1: (ApproveArgs) -> TransactionResponse;
+```
+
+
+#### transferFrom
+
+Moves the tokens
+
+```
+type TransferFromArgs = record {
+    to: principal;                   // User approved to spend
+    to_subaccount: opt SubAccount;    // Sub account to send the tokens to; If sub account is null the to address canmove to any sub account
+    from: principal;
+    from_subaccount: opt SubAccount; // sub account to pull tokens from; If sub account is null use the default account
+    amount: nat64;
+    fee: nat64;                      // fee willing to pay for the approve
+};
+
+transferFrom_ic1: (TransferFromArgs) -> TransactionResponse;
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The ICRC-1 is a standard for Fungible Tokens on the [Internet Computer](https://
 Returns the name of the token, e.g. `MyToken`.
 
 ```
-name: () -> (text) query;
+name_icrc: () -> (text) query;
 ```
 
 ### symbol
@@ -17,7 +17,7 @@ name: () -> (text) query;
 Returns the symbol of the token, e.g. `ICP`.
 
 ```
-symbol: () -> (text) query;
+symbol_icrc: () -> (text) query;
 ```
 
 ### decimals
@@ -25,7 +25,7 @@ symbol: () -> (text) query;
 Returns the number of decimals the token uses, e.g. `8`, means to divide the token amount by `100000000` to get its user representation.
 
 ```
-decimals: () -> (nat32) query;
+decimals_icrc: () -> (nat32) query;
 ```
 
 ### totalSupply
@@ -33,7 +33,7 @@ decimals: () -> (nat32) query;
 Returns the total token supply.
 
 ```
-totalSupply: () -> (nat32) query;
+totalSupply_icrc: () -> (nat64) query;
 ```
 
 ### balanceOf
@@ -41,7 +41,7 @@ totalSupply: () -> (nat32) query;
 Returns the balance of the account given as argument.
 
 ```
-balanceOf: (record { Principal; SubAccount; }) -> (nat64) query;
+balanceOf_icrc: (record { Principal; SubAccount; }) -> (nat64) query;
 ```
 
 ### transfer
@@ -54,9 +54,17 @@ type TransferArgs = record {
     to_principal: Principal;
     to_subaccount: opt SubAccount;
     amount: nat64;
+    callback: opt CallbackArgs;
+    memo: nat32;
+    fee: nat64;
 };
 
-transfer: (TransferArgs) -> (variant { Ok: nat64; Err: TransferError; });
+type CallbackArgs = record {
+    canister: Principal;
+    method: Text;
+};
+
+transfer_icrc: (TransferArgs) -> (variant { Ok: nat64; Err: TransferError; });
 ```
 
 The result is either the block index of the transfer or an error. The list of errors is:
@@ -66,4 +74,10 @@ type TransferError = variant {
     // TODO
     GenericError: text,
 };
+```
+
+The canister refrenced in the callback should implement the following signature:
+
+```
+    transfer_notified_icrc : (BlockArgs) -> () //one shot
 ```


### PR DESCRIPTION
I threw together this from the comments on the last meeting.  Everything is open for comment or criticism.  A couple of notes:

- I think we are going to have to support #pending return types especially when we get eth and BTC integration, so I updated the variant there.
- #noop is there in case a ledger wants to not charge a fee for an update call of some kind.  All should probably have a fee of some kind to prevent spamming.
- I've obviously updated this with namespacing because I think it is a good idea. All the functions end in _ic1. What if you are implementing two standards on one canister that use decimals?  For example, a ledger that supports trading some kind of trade interface that has a decimals() call that returns the number of supported decimals in the price field.  Won't someone think of the decimals?
- I've put a single principal to get the notification in there on transactions. If you leave it blank then no transaction. To do this we all need to agree on a standard function and payload. I haven't really looked at the block payload yet, but that probably deserves some debate as well.
- Approving has a fee and suggests moving funds to a separate sub-account, although I think that could technically be an implementation detail, but I think it should be a best practice.
- I considered changing the TOs and FROMS to a {#subaccount: {principal: Principal; subaccount: Blob;}; #account: Text} format, but held off for now as I'm not sure it is necessary.  Once we can dump subnet blocks people will be sifting through this info and I guess we should consider if we want that to be easy or hard.
- Before I forget, we need a batch send/approve/transferFrom, but I haven't added it yet.