### PR TITLE
[improve] did and readme

### DIFF
--- a/ICRC-1.did
+++ b/ICRC-1.did
@@ -2,9 +2,8 @@ type SubAccount = blob;
 
 type TransferArgs = record {
     from_subaccount: opt SubAccount;
-    to_principal: principal;
-    to_subaccount: opt SubAccount;
-    amount: nat64;
+    to: text;
+    amount: nat;
 };
 
 type TransferError = variant {
@@ -15,8 +14,8 @@ type TransferError = variant {
 service : {
     name: () -> (text) query;
     symbol: () -> (text) query;
-    decimals: () -> (nat32) query;
-    totalSupply: () -> (nat32) query;
-    balanceOf: (record { principal; SubAccount; }) -> (nat64) query;
-    transfer: (TransferArgs) -> (variant { Ok: nat64; Err: TransferError; });
+    decimals: () -> (nat8) query;
+    totalSupply: () -> (nat) query;
+    balanceOf: (text) -> (nat) query;
+    transfer: (TransferArgs) -> (variant { Ok: nat; Err: TransferError; });
 }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ symbol: () -> (text) query;
 Returns the number of decimals the token uses, e.g. `8`, means to divide the token amount by `100000000` to get its user representation.
 
 ```
-decimals: () -> (nat32) query;
+decimals: () -> (nat8) query;
 ```
 
 ### totalSupply
@@ -41,7 +41,7 @@ decimals: () -> (nat32) query;
 Returns the total token supply.
 
 ```
-totalSupply: () -> (nat32) query;
+totalSupply: () -> (nat) query;
 ```
 
 ### balanceOf
@@ -49,22 +49,21 @@ totalSupply: () -> (nat32) query;
 Returns the balance of the account given as argument.
 
 ```
-balanceOf: (record { Principal; SubAccount; }) -> (nat64) query;
+balanceOf: (text) -> (nat) query;
 ```
 
 ### transfer
 
-Transfers `amount` of tokens from the account `(caller, from_subaccount)` to the account `(to_principal, to_subaccount)`.
+Transfers `amount` of tokens from the account `(caller, from_subaccount)` to the account `principal/account_id`.
 
 ```
 type TransferArgs = record {
     from_subaccount: opt SubAccount;
-    to_principal: Principal;
-    to_subaccount: opt SubAccount;
-    amount: nat64;
+    to: text;
+    amount: nat;
 };
 
-transfer: (TransferArgs) -> (variant { Ok: nat64; Err: TransferError; });
+transfer: (TransferArgs) -> (variant { Ok: nat; Err: TransferError; });
 ```
 
 The result is either the block index of the transfer or an error. The list of errors is:


### PR DESCRIPTION
1. **Why not use (to_principal, to_subaccount) as the receiver parameter?**

When transferring token, the only thing the user can provide is the principal or accountid, subaccount is too difficult for ordinary users, so the transfer parameters should not use (to_principal, to_subaccount)

This is why the transfer parameter and the balanceOf parameter are modified

2. **Why to(the receiver) use text？** 
It can support the user to use either the principal or accountid string format

3. **Does the support principal and account id conflict with the definition of account?**
It won't. When the user provides the principal, the token standard implementation can internally convert to the default accountid for the user (subaccount = 0)

4. **Using to:text, if the wrong format of principal/account id is provided, what should token standard do?**
Check it internally first.
 
5. **Why do decimals use nat8?** 
Do your decimal places go beyond nat8? I don't think so.

6. **Why change totalSupply return to nat?**
nat32 is too small for many scenarios
