### PR TITLE
Account and SubAccount types

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ A `principal` can have multiple accounts. Each account of a `principal` is ident
 
 The account identified by the subaccount with all bytes set to 0 is the _default account_ of the `principal`.
 
+```
+type SubAccount = nat;
+type Account = record { principal; opt SubAccount; };
+```
+
 ## Methods
 
 ### icrc1_name
@@ -60,7 +65,7 @@ icrc1_total_supply : () -> (nat) query;
 Returns the balance of the account given as argument.
 
 ```
-icrc1_balance_of : (record { of: principal; subaccount: opt SubAccount; }) -> (nat) query;
+icrc1_balance_of : (Account) -> (nat) query;
 ```
 
 ### icrc1_transfer
@@ -70,8 +75,7 @@ Transfers `amount` of tokens from the account `(caller, from_subaccount)` to the
 ```
 type TransferArgs = record {
     from_subaccount: opt SubAccount;
-    to_principal: Principal;
-    to_subaccount: opt SubAccount;
+    to: Account;
     amount: nat;
     fee: opt nat;
     memo: opt nat64;

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ icrc1_balance_of : (Account) -> (nat) query;
 
 ### icrc1_transfer
 
-Transfers `amount` of tokens from the account `(caller, from_subaccount)` to the account `(to_principal, to_subaccount)`. The `fee` is paid by the `caller`.
+Transfers `amount` of tokens from the account `(caller, from_subaccount)` to the `Account`. The `fee` is paid by the `caller`.
 
 ```
 type TransferArgs = record {

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Transfers `amount` of tokens from the account `(caller, from_subaccount)` to the
 
 ```
 type TransferArgs = record {
-    from_subaccount: opt SubAccount;
+    from_subaccount: opt Subaccount;
     to: Account;
     amount: nat;
     fee: opt nat;

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ A `principal` can have multiple accounts. Each account of a `principal` is ident
 The account identified by the subaccount with all bytes set to 0 is the _default account_ of the `principal`.
 
 ```
-type SubAccount = nat;
-type Account = record { principal; opt SubAccount; };
+type Subaccount = blob;
+type Account = record { of: principal; subaccount: opt Subaccount; };
 ```
 
 ## Methods


### PR DESCRIPTION
I think `SubAccount` should be specified, and it would be nice to have an `Account` type instead of a separate principal and optional SubAccount everywhere.