### PR TITLE
Proposal: Rename principal in `Account` type

### DIFF
--- a/ICRC-1.did
+++ b/ICRC-1.did
@@ -4,12 +4,16 @@ type Timestamp = nat64;
 // Number of nanoseconds between two [Timestamp]service
 type Duration = nat64;
 
-type SubAccount = blob;
+type Subaccount = blob;
+
+type Account = record {
+    of: principal;
+    subaccount: opt Subaccount;
+};
 
 type TransferArgs = record {
-    from_subaccount: opt SubAccount;
-    to_principal: principal;
-    to_subaccount: opt SubAccount;
+    from_subaccount: opt Subaccount;
+    to: Account;
     amount: nat;
     fee: opt nat;
     memo: opt nat64;
@@ -39,7 +43,7 @@ service : {
     icrc1_symbol : () -> (text) query;
     icrc1_decimals : () -> (nat8) query;
     icrc1_total_supply : () -> (nat) query;
-    icrc1_balance_of : (record { of: principal; subaccount: opt SubAccount; }) -> (nat) query;
+    icrc1_balance_of : (Account) -> (nat) query;
     icrc1_transfer : (TransferArgs) -> (variant { Ok: nat; Err: TransferError; });
     icrc1_supported_standards : () -> (vec record { name : text; url : text }) query;
 }

--- a/ICRC-1.did
+++ b/ICRC-1.did
@@ -7,7 +7,7 @@ type Duration = nat64;
 type Subaccount = blob;
 
 type Account = record {
-    principal: principal;
+    "principal": principal;
     subaccount: opt Subaccount;
 };
 

--- a/ICRC-1.did
+++ b/ICRC-1.did
@@ -7,7 +7,7 @@ type Duration = nat64;
 type Subaccount = blob;
 
 type Account = record {
-    of: principal;
+    principal: principal;
     subaccount: opt Subaccount;
 };
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The account identified by the subaccount with all bytes set to 0 is the _default
 
 ```
 type Subaccount = blob;
-type Account = record { of: principal; subaccount: opt Subaccount; };
+type Account = record { principal: principal; subaccount: opt Subaccount; };
 ```
 
 ## Methods

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The account identified by the subaccount with all bytes set to 0 is the _default
 
 ```
 type Subaccount = blob;
-type Account = record { principal: principal; subaccount: opt Subaccount; };
+type Account = record { "principal": principal; subaccount: opt Subaccount; };
 ```
 
 ## Methods


### PR DESCRIPTION
The `Account` type is a combination of a principal and a subaccount. The subaccount was correctly called "subaccount" but the principal was called "of" for some reason. In the context of the `icrc1_balance_of` method, this makes sense. However, in the context of `icrc2_transfer` it does not.

In the future we may implement even more methods where "of" doesn't make sense as the name of the principal. By separating the usage from the definition, `Account` will remain flexible for all these use cases.

Additionally, when #26 was merged in we didn't update the did file. This takes care of that.