### PR TITLE
fix #31: add TransferError to the standard description

### DIFF
--- a/ICRC-1.did
+++ b/ICRC-1.did
@@ -23,7 +23,7 @@ type TransferError = variant {
     TooOld : record { allowed_window_nanos : Duration };
     CreatedInFuture;
     Duplicate : record { duplicate_of : nat };
-    GenericError: text;
+    GenericError : record { error_code : nat; message : text };
 };
 
 type Value = variant {


### PR DESCRIPTION
This change
  * Adds the missing TransferError definition to the standard.
  * Describes the semantics of memo and created_at_time fields
    and what error the client can expect.
  * Updates the type of GenericError to be more useful.