### PR TITLE
Proposal: larger memos

### DIFF
--- a/ICRC-1.did
+++ b/ICRC-1.did
@@ -16,7 +16,7 @@ type TransferArgs = record {
     to: Account;
     amount: nat;
     fee: opt nat;
-    memo: opt nat64;
+    memo: opt blob;
     created_at_time: opt Timestamp;
 };
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ type TransferArgs = record {
     to: Account;
     amount: nat;
     fee: opt nat;
-    memo: opt nat64;
+    memo: opt blob;
     created_at_time: opt nat64;
 };
 
@@ -103,7 +103,8 @@ The caller pays the `fee`.
 If the caller does not set the `fee` argument, the ledger applies the default transfer fee.
 If the `fee` argument does not agree with the ledger fee, the ledger MUST return `variant { BadFee = record { expected_fee = ... } }` error.
 
-The `memo` parameter is an arbitrary integer that has no meaning to the ledger.
+The `memo` parameter is an arbitrary blob has no meaning to the ledger.
+The ledger MUST allow memos of at least 32 bytes in length.
 The ledger MAY use the `memo` argument for transaction deduplication.
 
 The `created_at_time` parameter indicates the time (as nanoseconds since the UNIX epoch in the UTC timezone) at which the client constructed the transaction.

--- a/ref/ICRC1.mo
+++ b/ref/ICRC1.mo
@@ -22,7 +22,7 @@ actor class Ledger(init : {
   public type Account = { principal : Principal; subaccount : ?Subaccount };
   public type Subaccount = Blob;
   public type Tokens = Nat;
-  public type Memo = Nat64;
+  public type Memo = Blob;
   public type Timestamp = Nat64;
   public type Duration = Nat64;
   public type TxIndex = Nat;
@@ -158,6 +158,13 @@ actor class Ledger(init : {
     assert (subaccount.size() == 32);
   };
 
+  func validateMemo(m : ?Memo) {
+    switch (m) {
+      case (null) {};
+      case (?memo) { assert (memo.size() <= 32); };
+    }
+  };
+
   // The list of all transactions.
   var log : TxLog = makeGenesisChain();
 
@@ -202,6 +209,7 @@ actor class Ledger(init : {
 
     validateSubaccount(from_subaccount);
     validateSubaccount(to.subaccount);
+    validateMemo(memo);
 
     let from = { principal = caller; subaccount = from_subaccount };
 


### PR DESCRIPTION
This change proposes to extend memos from 8 bytes to a blob of at least
32 bytes in length.

This change has been discussed in the Working Group and suggested again in #30.