### PR TITLE
TransferError - TemporarilyUnavailable

### DIFF
--- a/ICRC-1.did
+++ b/ICRC-1.did
@@ -27,7 +27,7 @@ type TransferError = variant {
     TooOld : record { allowed_window_nanos : Duration };
     CreatedInFuture;
     Duplicate : record { duplicate_of : nat };
-    MaximumLoad;
+    TemporarilyUnavailable;
     GenericError : record { error_code : nat; message : text };
 };
 

--- a/ICRC-1.did
+++ b/ICRC-1.did
@@ -27,6 +27,7 @@ type TransferError = variant {
     TooOld : record { allowed_window_nanos : Duration };
     CreatedInFuture;
     Duplicate : record { duplicate_of : nat };
+    MaximumLoad;
     GenericError : record { error_code : nat; message : text };
 };
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ type TransferError = variant {
     TooOld : record { allowed_window_nanos : nat64 };
     CreatedInFuture;
     Duplicate : record { duplicate_of : nat };
-    MaximumLoad;
+    TemporarilyUnavailable;
     GenericError: record { error_code : nat; message : text };
 };
 ```

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ type TransferError = variant {
     TooOld : record { allowed_window_nanos : nat64 };
     CreatedInFuture;
     Duplicate : record { duplicate_of : nat };
+    MaximumLoad;
     GenericError: record { error_code : nat; message : text };
 };
 ```


### PR DESCRIPTION
For when a ledger wants to slow down the rate of the transfer calls. 

sample use case: to maintain a max-number of transactions in a single-canister's memory to check for a duplicate-transaction within a time-window.