### PR TITLE
Proposal: Account.principal → Account.owner

### DIFF
--- a/ICRC-1.did
+++ b/ICRC-1.did
@@ -7,8 +7,8 @@ type Duration = nat64;
 type Subaccount = blob;
 
 type Account = record {
-    "principal": principal;
-    subaccount: opt Subaccount;
+    owner : principal;
+    subaccount : opt Subaccount;
 };
 
 type TransferArgs = record {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The account identified by the subaccount with all bytes set to 0 is the _default
 
 ```candid "Type definitions" +=
 type Subaccount = blob;
-type Account = record { "principal": principal; subaccount: opt Subaccount; };
+type Account = record { owner: principal; subaccount: opt Subaccount; };
 ```
 
 ## Methods

--- a/ref/ICRC1.mo
+++ b/ref/ICRC1.mo
@@ -11,15 +11,15 @@ import Nat64         "mo:base/Nat64";
 
 
 actor class Ledger(init : {
-                     initial_mints : [ { account : { principal : Principal; subaccount : ?Blob }; amount : Nat } ];
-                     minting_account : { principal : Principal; subaccount : ?Blob };
+                     initial_mints : [ { account : { owner : Principal; subaccount : ?Blob }; amount : Nat } ];
+                     minting_account : { owner : Principal; subaccount : ?Blob };
                      token_name : Text;
                      token_symbol : Text;
                      decimals : Nat8;
                      transfer_fee : Nat;
                   }) = this {
 
-  public type Account = { principal : Principal; subaccount : ?Subaccount };
+  public type Account = { owner : Principal; subaccount : ?Subaccount };
   public type Subaccount = Blob;
   public type Tokens = Nat;
   public type Memo = Blob;
@@ -73,7 +73,7 @@ actor class Ledger(init : {
     let lhsSubaccount = Option.get(lhs.subaccount, defaultSubaccount);
     let rhsSubaccount = Option.get(rhs.subaccount, defaultSubaccount);
 
-    Principal.equal(lhs.principal, rhs.principal) and Blob.equal(lhsSubaccount, rhsSubaccount)
+    Principal.equal(lhs.owner, rhs.owner) and Blob.equal(lhsSubaccount, rhsSubaccount)
   };
 
   // Computes the balance of the specified account.
@@ -211,7 +211,7 @@ actor class Ledger(init : {
     validateSubaccount(to.subaccount);
     validateMemo(memo);
 
-    let from = { principal = caller; subaccount = from_subaccount };
+    let from = { owner = caller; subaccount = from_subaccount };
 
     let args : Transfer = {
       from = from;


### PR DESCRIPTION
The working group decided to rename `Account.principal` to `Account.owner`
because "principal" is a reserved symbol in Candid, which might create
unnecessary friction for people trying to call the ledger using dfx.