### PR TITLE
fix: add missing `from_subaccount` in ICRC-2.did

### DIFF
--- a/standards/ICRC-2/ICRC-2.did
+++ b/standards/ICRC-2/ICRC-2.did
@@ -4,6 +4,7 @@ type Account = record {
 };
 
 type ApproveArgs = record {
+    from_subaccount : opt blob;
     spender : principal;
     amount : nat;
     fee : opt nat;


### PR DESCRIPTION
ApproveArgs is missing this field in the did file