### PR TITLE
ICRC-2 Separate approval allowances and honor the set expiration in an approval-request.

### DIFF
--- a/standards/ICRC-2/ICRC-2.did
+++ b/standards/ICRC-2/ICRC-2.did
@@ -6,7 +6,7 @@ type Account = record {
 type ApproveArgs = record {
     from_subaccount : opt blob;
     spender : principal;
-    amount : int;
+    amount : nat;
     expires_at : opt nat64;
     fee : opt nat;
     memo : opt blob;
@@ -45,9 +45,30 @@ type TransferFromError = variant {
     GenericError : record { error_code : nat; message : text };
 };
 
-type AllowanceArgs = record {
+type AllowancesArgs = record {
     account : Account;
     spender : principal;
+    start : opt nat;
+};
+
+type AllowancesData = record {
+    latest_approval_id : opt nat;
+    total_allowance : nat;
+    allowances : vec Allowance;
+};
+
+type Allowance = record {
+  approval_id: nat;
+  allowance : nat;
+  expires_at : opt nat64;
+};
+
+
+type CancelApprovalError = variant {
+    ApprovalNotFound;
+    CallerIsNotTheApprover;
+    ApprovalIsExpired;
+    ApprovalIsCanceled : record { cancellation: nat; };
 };
 
 service : {
@@ -55,5 +76,6 @@ service : {
 
     icrc2_approve : (ApproveArgs) -> (variant { Ok : nat; Err : ApproveError });
     icrc2_transfer_from : (TransferFromArgs) -> (variant { Ok : nat; Err : TransferFromError });
-    icrc2_allowance : (AllowanceArgs) -> (record { allowance : nat; expires_at : opt nat64 }) query;
+    icrc2_allowances : (AllowancesArgs) -> (AllowancesData) query;
+    icrc2_cancel_approval : (nat) -> (variant { Ok : nat; Err : CancelApprovalError });
 }

--- a/standards/ICRC-2/ICRC-2.did
+++ b/standards/ICRC-2/ICRC-2.did
@@ -67,8 +67,6 @@ type Allowance = record {
 type CancelApprovalError = variant {
     ApprovalNotFound;
     CallerIsNotTheApprover;
-    ApprovalIsExpired;
-    ApprovalIsCanceled : record { cancellation: nat; };
 };
 
 service : {

--- a/standards/ICRC-2/README.md
+++ b/standards/ICRC-2/README.md
@@ -198,8 +198,6 @@ icrc2_cancel_approval : (nat) -> (variant { Ok : nat; Err : CancelApprovalError 
 type CancelApprovalError = variant {
     ApprovalNotFound;
     CallerIsNotTheApprover;
-    ApprovalIsExpired;
-    ApprovalIsCanceled : record { cancellation: nat; };
 };
 
 ```
@@ -213,10 +211,10 @@ type CancelApprovalError = variant {
    Otherwise, the ledger MUST return an `CallerIsNotTheApprover` error.
     
  * The approval must not be expired.
-  Otherwise, the ledger MUST return an `ApprovalIsExpired` error.
+  Otherwise, the ledger MUST return an `ApprovalNotFound` error.
 
  * The approval must not have been previously canceled.
-  Otherwise, the ledger MUST return an `ApprovalIsCanceled` error with the cancellation block-id.
+  Otherwise, the ledger MUST return an `ApprovalNotFound` error.
 
 #### Postconditions
 


### PR DESCRIPTION
Fixes: #93 

This change separates approvals made for the same Account-Spender pair into separate allowances each with their own expiration of the expiration set in the specific approval request.

This change lets the ledger honor the expiration time of a specific approval-allowance even if multiple overlapping approvals are made for the same Account-Spender pair. 

Before this change, when multiple overlapping approvals were made for the same Account-Spender pair, the ledger would have set the expiration of the spender's allowance to the expiration of the latest approval request, carrying over the allowance from the previous approval requests but not carrying over the expiration of the previous approval requests, therefore giving the spender the allowance from an approval-request that may have been expired. 

The solution of this change gives each approval a separate allowance & expiration even for the same Account-Spender pair. 

When a Spender calls `icrc2_transfer_from`, the ledger calculates the **total**-allowance for the Account-Spender pair by taking the **sum** of the current (unexpired) allowances for that Account-Spender pair. Then the ledger goes through the allowances one by one starting with the allowance expiring soonest and deducts the transfer amount + fee from the total-allowance. 

The `TransferFromArg` stays the same.

The `icrc2_allowances` method now returns the total-allowance for the Account-Spender pair and can show each specific approval allowance and expiration.

The `icrc2_cancel_approval` method can be used by an approver to cancel an existing approval. Any remaining allowance of that specific approval will be canceled. The method is called using the original approval block id as the parameter, and returns with the block-id of the approval-cancellation.