### PR TITLE
feat: use ERC-20 semantics for approvals

### DIFF
--- a/standards/ICRC-2/ICRC-2.did
+++ b/standards/ICRC-2/ICRC-2.did
@@ -5,8 +5,9 @@ type Account = record {
 
 type ApproveArgs = record {
     from_subaccount : opt blob;
-    spender : principal;
-    amount : int;
+    spender : Account;
+    amount : nat;
+    expected_allowance : opt nat;
     expires_at : opt nat64;
     fee : opt nat;
     memo : opt blob;
@@ -16,6 +17,7 @@ type ApproveArgs = record {
 type ApproveError = variant {
     BadFee : record { expected_fee : nat };
     InsufficientFunds : record { balance : nat };
+    AllowanceChanged : record { current_allowance : nat };
     Expired : record { ledger_time : nat64 };
     TooOld;
     CreatedInFuture: record { ledger_time : nat64 };
@@ -47,7 +49,7 @@ type TransferFromError = variant {
 
 type AllowanceArgs = record {
     account : Account;
-    spender : principal;
+    spender : Account;
 };
 
 service : {

--- a/standards/ICRC-2/README.md
+++ b/standards/ICRC-2/README.md
@@ -197,7 +197,7 @@ icrc1_supported_standards : () -> (vec record { name : text; url : text }) query
 
 1. Canister C wants to transfer 100 tokens on an `ICRC-2` ledger from Alice's account to Bob's account.
 2. Alice previously approved canister C to transfer tokens on her behalf by calling `icrc2_approve` with `spender` set to the canister's default account (`{ owner = C; subaccount = null }`) and `amount` set to the token amount she wants to allow (100) plus the transfer fee.
-3. During some update call, the canister can now call `icrc2_transfer_from` with `from` set to Alice's account, `to` set to Bob's account, and `amount` set to the token amount she wants to transfer (100 plus the transfer fee).
+3. During some update call, the canister can now call `icrc2_transfer_from` with `from` set to Alice's account, `to` set to Bob's account, and `amount` set to the token amount she wants to transfer (100).
 4. Once the call completes successfully, Bob has 100 extra tokens on his account, and Alice has 100 (plus the fee) tokens less in her account.
 
 ### Alice removes her allowance for canister C

--- a/standards/ICRC-2/README.md
+++ b/standards/ICRC-2/README.md
@@ -53,7 +53,7 @@ The number of transfers the `spender` can initiate from the caller's account is 
 The caller does not need to have the full token `amount` on the specified account for the approval to succeed, just enough tokens to pay the approval fee.
 The call resets the allowance and the expiration date for the `spender` account to the given values.
 
-The ledger SHOULD reject the call if the spender account is equal to the source account (`{ owner = caller; subaccount = from_subaccount } == spender`).
+The ledger SHOULD reject the call if the spender account owner is equal to the source account owner.
 
 If the `expected_allowance` field is set, the ledger MUST ensure that the current allowance for the `spender` from the caller's account is equal to the given value and return the `AllowanceChanged` error otherwise.
 

--- a/standards/ICRC-2/README.md
+++ b/standards/ICRC-2/README.md
@@ -10,9 +10,11 @@
 `ICRC-2` specifies a way for an account owner to delegate token transfers to a third party on the owner's behalf.
 
 The approve and transfer-from flow is a 2-step process.
-1. Account owner Alice entitles principal Bob to transfer up to X tokens from her account A by calling the `icrc2_approve` method on the ledger.
-2. Bob can transfer up to X tokens from account A to any account by calling the `icrc2_transfer_from` method on the ledger.
+1. Account owner Alice entitles Bob to transfer up to X tokens from her account A by calling the `icrc2_approve` method on the ledger.
+2. Bob can transfer up to X tokens from account A to any account by calling the `icrc2_transfer_from` method on the ledger as if A was Bob's account B.
    The number of transfers Bob can initiate from account A is not limited as long as the total amount spent is below X.
+
+Approvals are not transitive: if Alice approves transfers from her account A to Bob's account B, and Bob approves transfers from his account B to Eva's account E, Eva cannot withdraw tokens from Alice's account through Bob's approval.
 
 ## Motivation
 
@@ -20,7 +22,7 @@ The approve-transfer-from pattern became popular in the Ethereum ecosystem thank
 This interface enables new application capabilities:
 
   1. Recurring payments.
-     Alice can approve a large amount to Bob in advance, allowing Bob to make periodic transfers in small installments.
+     Alice can approve a large amount to Bob in advance, allowing Bob to make periodic transfers in smaller installments.
      Real-world examples include subscription services and rents.
 
   2. Uncertain transfer amounts.
@@ -46,16 +48,17 @@ type Account = record {
 
 ### icrc2_approve
 
-Entitles the `spender` to transfer an additional token `amount` on behalf of the caller from account `{ owner = caller; subaccount = from_subaccount }`.
+This method entitles the `spender` to transfer token `amount` on behalf of the caller from account `{ owner = caller; subaccount = from_subaccount }`.
 The number of transfers the `spender` can initiate from the caller's account is unlimited as long as the total amounts and fees of these transfers do not exceed the allowance.
 The caller does not need to have the full token `amount` on the specified account for the approval to succeed, just enough tokens to pay the approval fee.
-The `spender`'s allowance for the account increases or decreases by the `amount` depending on the sign of the `amount` field. 
-If the `expires_at` field is not null, the ledger resets the approval expiration time to the specified value.
+The call resets the allowance and the expiration date for the `spender` account to the given values.
 
-The ledger SHOULD reject the request if the caller is the same principal as the spender (no self-approvals allowed).
+The ledger SHOULD reject the call if the spender account is equal to the source account (`{ owner = caller; subaccount = from_subaccount } == spender`).
+
+If the `expected_allowance` field is set, the ledger MUST ensure that the current allowance for the `spender` from the caller's account is equal to the given value and return the `AllowanceChanged` error otherwise.
 
 The ledger MAY cap the total allowance if it becomes too large (for example, larger than the total token supply).
-For example, if there are only 100 tokens, and the ledger receives two approvals for 60 tokens for the same `(account, principal)` pair, the ledger may cap the total allowance to 100.
+For example, if there are only 100 tokens, and the ledger receives two approvals for 60 tokens for the same `(owner, spender)` pair, the ledger may cap the total allowance to 100.
 
 ```candid "Methods" +=
 icrc2_approve : (ApproveArgs) -> (variant { Ok : nat; Err : ApproveError });
@@ -64,8 +67,9 @@ icrc2_approve : (ApproveArgs) -> (variant { Ok : nat; Err : ApproveError });
 ```candid "Type definitions" +=
 type ApproveArgs = record {
     from_subaccount : opt blob;
-    spender : principal;
-    amount : int;
+    spender : Account;
+    amount : nat;
+    expected_allowance : opt nat;
     expires_at : opt nat64;
     fee : opt nat;
     memo : opt blob;
@@ -76,6 +80,9 @@ type ApproveError = variant {
     BadFee : record { expected_fee : nat };
     // The caller does not have enough funds to pay the approval fee.
     InsufficientFunds : record { balance : nat };
+    // The caller specified the [expected_allowance] field, and the current
+    // allowance did not match the given value.
+    AllowanceChanged : record { current_allowance : nat };
     // The approval request expired before the ledger had a chance to apply it.
     Expired : record { ledger_time : nat64; };
     TooOld;
@@ -89,19 +96,17 @@ type ApproveError = variant {
 #### Preconditions
 
 * The caller has enough fees on the `{ owner = caller; subaccount = from_subaccount }` account to pay the approval fee.
-* The caller is different from the `spender`.
-* If the `expires_at` field is set, it's creater than the current ledger time.
+* If the `expires_at` field is set, it's greater than the current ledger time.
+* If the `expected_allowance` field is set, it's equal to the current allowance for the `spender`.
 
 #### Postconditions
 
 * The `spender`'s allowance for the `{ owner = caller; subaccount = from_subaccount }` increases by the `amount` (or decreases if the `amount` is negative).
-  If the total allowance is negative, the ledger MUST reset the allowance to zero.
 
 ### icrc2_transfer_from
 
-Transfers a token amount from between two accounts.
+Transfers a token amount from the `from` account to the `to` account using the allowance of the spender's account (`SpenderAccount = { owner = caller; subaccount = spender_subaccount }`).
 The ledger draws the fees from the `from` account.
-If the caller is the owner of the `from` account, `icrc2_transfer_from` ignores allowances and acts as an `icrc1_transfer`.
 
 ```candid "Methods" +=
 icrc2_transfer_from : (TransferFromArgs) -> (variant { Ok : nat; Err : TransferFromError });
@@ -123,6 +128,7 @@ type TransferFromError = variant {
 };
 
 type TransferFromArgs = record {
+    spender_subaccount : opt blob;
     from : Account;
     to : Account;
     amount : nat;
@@ -134,21 +140,24 @@ type TransferFromArgs = record {
 
 #### Preconditions
  
- * If the caller is no the `from` account owner, the caller's allowance for the `from` account is large enough to cover the transfer amount and the fees.
+ * The allowance for the `SpenderAccount` from the `from` account is large enough to cover the transfer amount and the fees
+   (`icrc2_allowance({ account = from; spender = SpenderAccount }).allowance >= amount + fee`). 
    Otherwise, the ledger MUST return an `InsufficientAllowance` error.
 
 * The `from` account holds enough funds to cover the transfer amount and the fees.
+  (`icrc1_balance_of(from) >= amount + fee`).
   Otherwise, the ledger MUST return an `InsufficientFunds` error.
+
  #### Postconditions
 
- * If the caller is not the `from` account owner, caller's allowance for the `from` account decreases by the transfer amount and the fees.
+ * If the `from` account is not equal to the `SpenderAccount`, the `(from, SpenderAccount)` allowance decreases by the transfer amount and the fees.
  * The ledger debited the specified `amount` of tokens and fees from the `from` account.
  * The ledger credited the specified `amount` to the `to` account.
 
 ### icrc2_allowance
 
-Returns the token allowance that the `spender` can transfer from the specified `account`, and the expiration time for that allowance, if any.
-If there is no active approval, the ledger MUST return `0`.
+Returns the token allowance that the `spender` account can transfer from the specified `account`, and the expiration time for that allowance, if any.
+If there is no active approval, the ledger MUST return `{ allowance = 0; expires_at = null }`.
 
 ```candid "Methods" +=
 icrc2_allowance : (AllowanceArgs) -> (Allowance) query;
@@ -156,7 +165,7 @@ icrc2_allowance : (AllowanceArgs) -> (Allowance) query;
 ```candid "Type definitions" +=
 type AllowanceArgs = record {
     account : Account;
-    spender : principal;
+    spender : Account;
 };
 
 type Allowance = record {
@@ -164,6 +173,7 @@ type Allowance = record {
   expires_at : opt nat64;
 }
 ```
+
 ### icrc1_supported_standards
 
 Returns the list of standards this ledger supports.
@@ -175,26 +185,33 @@ icrc1_supported_standards : () -> (vec record { name : text; url : text }) query
 
 ## Examples
 
-### Alice deposits tokens to a canister
+### Alice deposits tokens to canister C
 
-1. Alice wants to deposit 100 tokens on an `ICRC-2` ledger to a canister.
-2. Alice calls `icrc2_approve` with `spender` set to the canister's principal and `amount` set to the token amount she wants to deposit (100) plus the transfer fee.
+1. Alice wants to deposit 100 tokens on an `ICRC-2` ledger to canister C.
+2. Alice calls `icrc2_approve` with `spender` set to the canister's default account (`{ owner = C; subaccount = null}`) and `amount` set to the token amount she wants to deposit (100) plus the transfer fee.
 3. Alice can then call some `deposit` method on the canister, which calls `icrc2_transfer_from` with `from` set to Alice's (the caller) account, `to` set to the canister's account, and `amount` set to the token amount she wants to deposit (100).
 4. The canister can now determine from the result of the call whether the transfer was successful.
    If it was successful, the canister can now safely commit the deposit to state and know that the tokens are in its account.
 
-### A canister transfers tokens from Alice's account to Bob's account, on Alice's behalf
+### Canister C transfers tokens from Alice's account to Bob's account, on Alice's behalf
 
-1. A canister wants to transfer 100 tokens on an `ICRC-2` ledger from Alice's account to Bob's account.
-2. Alice previously approved the canister to transfer tokens on her behalf by calling `icrc2_approve` with `spender` set to the canister's principal and `amount` set to the token amount she wants to allow (100) plus the transfer fee.
-3. During some update call, the canister can now call `icrc2_transfer_from` with `from` set to Alice's account, `to` set to Bob's account, and `amount` set to the token amount she wants to transfer (100).
-4. Depending on the result of the call, Bob now has 100 tokens in his account, and Alice has 100 tokens less in her account.
+1. Canister C wants to transfer 100 tokens on an `ICRC-2` ledger from Alice's account to Bob's account.
+2. Alice previously approved canister C to transfer tokens on her behalf by calling `icrc2_approve` with `spender` set to the canister's default account (`{ owner = C; subaccount = null }`) and `amount` set to the token amount she wants to allow (100) plus the transfer fee.
+3. During some update call, the canister can now call `icrc2_transfer_from` with `from` set to Alice's account, `to` set to Bob's account, and `amount` set to the token amount she wants to transfer (100 plus the transfer fee).
+4. Once the call completes successfully, Bob has 100 extra tokens on his account, and Alice has 100 (plus the fee) tokens less in her account.
 
-### Alice wants to remove her allowance for a canister
+### Alice removes her allowance for canister C
 
-1. Alice wants to remove her allowance of 100 tokens on an `ICRC-2` ledger for a canister.
-2. Alice calls `icrc2_approve` on the ledger with `spender` set to the canister's principal and `amount` set to 0.
+1. Alice wants to remove her allowance of 100 tokens on an `ICRC-2` ledger for canister C.
+2. Alice calls `icrc2_approve` on the ledger with `spender` set to the canister's default account (`{ owner = C; subaccount = null }`) and `amount` set to 0.
 3. The canister can no longer transfer tokens on Alice's behalf.
+
+### Alice atomically removes her allowance for canister C
+
+1. Alice wants to remove her allowance of 100 tokens on an `ICRC-2` ledger for canister C.
+2. Alice calls `icrc2_approve` on the ledger with `spender` set to the canister's default account (`{ owner = C; subaccount = null }`), `amount` set to 0, and `expected_allowance` set to 100 tokens.
+3. If the call succeeds, the allowance got removed successfully.
+   An `AllowanceChanged` error would indicate that canister C used some of the allowance before Alice's call completed.
 
 <!--
 ```candid ICRC-2.did +=

--- a/standards/ICRC-2/README.md
+++ b/standards/ICRC-2/README.md
@@ -101,7 +101,7 @@ type ApproveError = variant {
 
 #### Postconditions
 
-* The `spender`'s allowance for the `{ owner = caller; subaccount = from_subaccount }` increases by the `amount` (or decreases if the `amount` is negative).
+* The `spender`'s allowance for the `{ owner = caller; subaccount = from_subaccount }` is equal to the given `amount`.
 
 ### icrc2_transfer_from
 


### PR DESCRIPTION
This change incorporates the feedback from the Working Group session on 2023-04-18:

  1. We change the semantics of approvals to be closer to ERC-20. A call to icrc2_approve overwrites the previous allowance and the timestamp.

   2. Allowances target accounts, not principals. This change will enable fine-grained control in DApps and significantly simplify implementation for ledgers that rely on AccountIdentifiers internally, such as the ICP ledger.

   3. For applications that need concurrent approvals, we add optional "compare and swap" semantics of approvals. If the caller specifies the optional `expected_allowance` field, the ledger will return an error if the allowance changes before the ledger accepts the `approve` call.

TODO: update the reference implementation once we agree on the semantics.
