### PR TITLE
Update BasicIdentity -> Secp256k1Identity

### DIFF
--- a/test/runner/main.rs
+++ b/test/runner/main.rs
@@ -1,5 +1,5 @@
 use ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport;
-use ic_agent::identity::BasicIdentity;
+use ic_agent::identity::Secp256k1Identity;
 use ic_agent::Agent;
 use ic_types::Principal;
 use icrc1_test_env::LedgerEnv;
@@ -52,7 +52,7 @@ async fn main() {
             std::process::exit(1);
         });
 
-    let identity = BasicIdentity::from_pem_file(&key_path).unwrap_or_else(|e| {
+    let identity = Secp256k1Identity::from_pem_file(&key_path).unwrap_or_else(|e| {
         panic!(
             "failed to parse secret key PEM from file {}: {}",
             key_path.display(),


### PR DESCRIPTION
Closes issue #115 occurring due to use BasicIdentity instead of Secp256k1Identity used in more recent **dfx** releases and giving the following error `A key was rejected by Ring: InvalidEncoding', test/runner/main.rs:56:9`