### PR TITLE
chore: FI-1858: Update actions/cache to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Mount bazel cache
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: "/home/runner/.cache/bazel"
         key: bazel


### PR DESCRIPTION
The CI workflow currently fails for most/all PRs since `v1` of `actions/cache` is no longer supported (see e.g., [this workflow run](https://github.com/dfinity/ICRC-1/actions/runs/17473950694/job/49629044996?pr=200)). This PR proposes to bump the version to `v3` as suggested in the error message in the failed workflow run.