### PR TITLE
chore: FI-1858: Bump crate versions and deprecate icrc1-test-env-state-machine

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "cc8ebd94d80cc098a21f08dbd3985420b629be50ef78177389bb86f35c0e84ae",
+  "checksum": "f6ff6bcf5edf70849b03ea8aa41e56b31985defcf341b0badc9a81a3252abb1c",
   "crates": {
     "addr2line 0.24.2": {
       "name": "addr2line",
@@ -5993,9 +5993,9 @@
       ],
       "license_file": "LICENSE"
     },
-    "icrc1-test-env 0.1.2": {
+    "icrc1-test-env 0.1.12": {
       "name": "icrc1-test-env",
-      "version": "0.1.2",
+      "version": "0.1.12",
       "package_url": "https://github.com/dfinity/ICRC-1",
       "repository": null,
       "targets": [
@@ -6048,7 +6048,7 @@
           ],
           "selects": {}
         },
-        "version": "0.1.2"
+        "version": "0.1.12"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -6056,9 +6056,9 @@
       ],
       "license_file": null
     },
-    "icrc1-test-env-replica 0.1.2": {
+    "icrc1-test-env-replica 0.1.12": {
       "name": "icrc1-test-env-replica",
-      "version": "0.1.2",
+      "version": "0.1.12",
       "package_url": "https://github.com/dfinity/ICRC-1",
       "repository": null,
       "targets": [
@@ -6119,7 +6119,7 @@
           ],
           "selects": {}
         },
-        "version": "0.1.2"
+        "version": "0.1.12"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -6127,9 +6127,9 @@
       ],
       "license_file": null
     },
-    "icrc1-test-env-state-machine 0.1.2": {
+    "icrc1-test-env-state-machine 0.1.12": {
       "name": "icrc1-test-env-state-machine",
-      "version": "0.1.2",
+      "version": "0.1.12",
       "package_url": "https://github.com/dfinity/ICRC-1",
       "repository": null,
       "targets": [
@@ -6182,7 +6182,7 @@
           ],
           "selects": {}
         },
-        "version": "0.1.2"
+        "version": "0.1.12"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -6190,9 +6190,9 @@
       ],
       "license_file": null
     },
-    "icrc1-test-replica 0.1.2": {
+    "icrc1-test-replica 0.1.12": {
       "name": "icrc1-test-replica",
-      "version": "0.1.2",
+      "version": "0.1.12",
       "package_url": "https://github.com/dfinity/ICRC-1",
       "repository": null,
       "targets": [
@@ -6236,7 +6236,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.2"
+        "version": "0.1.12"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -6244,9 +6244,9 @@
       ],
       "license_file": null
     },
-    "icrc1-test-runner 0.1.2": {
+    "icrc1-test-runner 0.1.12": {
       "name": "icrc1-test-runner",
-      "version": "0.1.2",
+      "version": "0.1.12",
       "package_url": "https://github.com/dfinity/ICRC-1",
       "repository": null,
       "targets": [],
@@ -6285,7 +6285,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.2"
+        "version": "0.1.12"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -6293,9 +6293,9 @@
       ],
       "license_file": null
     },
-    "icrc1-test-suite 0.1.2": {
+    "icrc1-test-suite 0.1.12": {
       "name": "icrc1-test-suite",
-      "version": "0.1.2",
+      "version": "0.1.12",
       "package_url": "https://github.com/dfinity/ICRC-1",
       "repository": null,
       "targets": [
@@ -6335,7 +6335,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.2"
+        "version": "0.1.12"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -18968,12 +18968,12 @@
   },
   "binary_crates": [],
   "workspace_members": {
-    "icrc1-test-env 0.1.2": "test/env",
-    "icrc1-test-env-replica 0.1.2": "test/env/replica",
-    "icrc1-test-env-state-machine 0.1.2": "test/env/state-machine",
-    "icrc1-test-replica 0.1.2": "test/replica",
-    "icrc1-test-runner 0.1.2": "test/runner",
-    "icrc1-test-suite 0.1.2": "test/suite"
+    "icrc1-test-env 0.1.12": "test/env",
+    "icrc1-test-env-replica 0.1.12": "test/env/replica",
+    "icrc1-test-env-state-machine 0.1.12": "test/env/state-machine",
+    "icrc1-test-replica 0.1.12": "test/replica",
+    "icrc1-test-runner 0.1.12": "test/runner",
+    "icrc1-test-suite 0.1.12": "test/suite"
   },
   "conditions": {
     "aarch64-apple-darwin": [

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "f6ff6bcf5edf70849b03ea8aa41e56b31985defcf341b0badc9a81a3252abb1c",
+  "checksum": "a0e7808cb919e059b5ac81f8b121ac4f7aca995262a8bf972f6a9dc2403d8381",
   "crates": {
     "addr2line 0.24.2": {
       "name": "addr2line",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "icrc1-test-env"
-version = "0.1.2"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "icrc1-test-env-replica"
-version = "0.1.2"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "icrc1-test-env-state-machine"
-version = "0.1.2"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "icrc1-test-replica"
-version = "0.1.2"
+version = "0.1.12"
 dependencies = [
  "ic-agent",
  "reqwest",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "icrc1-test-runner"
-version = "0.1.2"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "candid",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "icrc1-test-suite"
-version = "0.1.2"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "candid",

--- a/test/env/Cargo.toml
+++ b/test/env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icrc1-test-env"
-version = "0.1.2"
+version = "0.1.12"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/test/env/Changelog.md
+++ b/test/env/Changelog.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.12] - 2025-09-08
+### Changed
+- Bump rust to 1.85.0
+
+## [0.1.11] - 2024-01-16
+### Added
+- Duplicate release of 0.1.2
+
 ## [0.1.2] - 2024-01-16
 ### Changed
 - Use candid 0.10

--- a/test/env/replica/Cargo.toml
+++ b/test/env/replica/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icrc1-test-env-replica"
-version = "0.1.2"
+version = "0.1.12"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
@@ -19,4 +19,4 @@ rand = { workspace = true }
 ring = "0.16.20"
 hex = { workspace = true }
 async-trait = { workspace = true }
-icrc1-test-env = { version = "0.1.2", path = "../" }
+icrc1-test-env = { version = "0.1.12", path = ".." }

--- a/test/env/replica/Changelog.md
+++ b/test/env/replica/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.12] - 2025-09-08
+### Changed
+- Use rust 1.85.0
+
 ## [0.1.2] - 2024-01-16
 ### Changed
 - Use candid 0.10

--- a/test/env/replica/Changelog.md
+++ b/test/env/replica/Changelog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.12] - 2025-09-08
 ### Changed
 - Use rust 1.85.0
+- Use icrc1-test-env 0.1.12
 
 ## [0.1.2] - 2024-01-16
 ### Changed

--- a/test/env/state-machine/Cargo.toml
+++ b/test/env/state-machine/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "icrc1-test-env-state-machine"
-version = "0.1.2"
+version = "0.1.12"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }
 repository = { workspace = true }
-description = { workspace = true }
+description = "DEPRECATED: Use icrc1-test-env-pocket-ic"
 
 [lib]
 path = "lib.rs"
@@ -17,4 +17,4 @@ candid = { workspace = true }
 async-trait = { workspace = true }
 hex = { workspace = true }
 ic-test-state-machine-client = { workspace = true }
-icrc1-test-env = { version = "0.1.2", path = "../" }
+icrc1-test-env = { version = "0.1.12", path = ".." }

--- a/test/env/state-machine/Changelog.md
+++ b/test/env/state-machine/Changelog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.12] - 2024-09-08
 ### Changed
 - Use rust 1.85.0
+- Use icrc1-test-env 0.1.12
 #### Deprecated
 - This crate is deprecated - migrate to the soon-to-be-released icrc1-test-env-pocket-ic crate instead
 

--- a/test/env/state-machine/Changelog.md
+++ b/test/env/state-machine/Changelog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.12] - 2024-09-08
+### Changed
+- Use rust 1.85.0
+#### Deprecated
+- This crate is deprecated - migrate to the soon-to-be-released icrc1-test-env-pocket-ic crate instead
+
 ## [0.1.2] - 2024-01-16
 ### Changed
 - Use candid 0.10

--- a/test/replica/Cargo.toml
+++ b/test/replica/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icrc1-test-replica"
-version = "0.1.2"
+version = "0.1.12"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/test/replica/Changelog.md
+++ b/test/replica/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.12] - 2025-09-08
+### Changed
+- Use rust 1.85.0
+
 ## [0.1.2] - 2024-01-16
 ### Changed
 - Use candid 0.10

--- a/test/runner/Cargo.toml
+++ b/test/runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icrc1-test-runner"
-version = "0.1.2"
+version = "0.1.12"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
@@ -13,9 +13,9 @@ name = "runner"
 path = "main.rs"
 
 [dependencies]
-icrc1-test-env = { version ="0.1.2", path = "../env" }
-icrc1-test-env-replica = { version ="0.1.2", path = "../env/replica" }
-icrc1-test-suite = { version ="0.1.2", path = "../suite" }
+icrc1-test-env = { version ="0.1.12", path = "../env" }
+icrc1-test-env-replica = { version ="0.1.12", path = "../env/replica" }
+icrc1-test-suite = { version ="0.1.12", path = "../suite" }
 ic-agent = { workspace = true }
 pico-args = "0.5"
 reqwest = { workspace = true }

--- a/test/runner/Changelog.md
+++ b/test/runner/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.12] - 2025-09-08
+### Changed
+- Use rust 1.85.0
+
 ## [0.1.2] - 2024-01-16
 ### Changed
 - Use candid 0.10

--- a/test/runner/Changelog.md
+++ b/test/runner/Changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.12] - 2025-09-08
 ### Changed
 - Use rust 1.85.0
+- Use icrc1-test-env 0.1.12
+- Use icrc1-test-env-replica 0.1.12
+- Use icrc1-test-suite 0.1.12
 
 ## [0.1.2] - 2024-01-16
 ### Changed

--- a/test/suite/Cargo.toml
+++ b/test/suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icrc1-test-suite"
-version = "0.1.2"
+version = "0.1.12"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
@@ -15,4 +15,4 @@ path = "lib.rs"
 anyhow = "1.0"
 candid = { workspace = true }
 futures = "0.3.24"
-icrc1-test-env = { version ="0.1.2", path = "../env" }
+icrc1-test-env = { version ="0.1.12", path = "../env" }

--- a/test/suite/Changelog.md
+++ b/test/suite/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.12] - 2025-09-08
+### Changed
+- Use rust 1.85.0
+
 ## [0.1.2] - 2024-01-16
 ### Changed
 - Use candid 0.10

--- a/test/suite/Changelog.md
+++ b/test/suite/Changelog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.12] - 2025-09-08
 ### Changed
 - Use rust 1.85.0
+- Use icrc1-test-env 0.1.12
 
 ## [0.1.2] - 2024-01-16
 ### Changed


### PR DESCRIPTION
Bump the crate versions to `0.1.12` and mark the `icrc1-test-env-state-machine` as deprecated, since it will be migrated to/replaced by the `icrc1-test-env-pocket-ic` crate.