### PR TITLE
chore: changing owners to defi team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@dfinity/finint
+@dfinity/defi-team


### PR DESCRIPTION
The financial integrations team was merged with the cross chain team and is now part of the defi team.