### PR TITLE
Add ICRC-2 Advisory Clarifying Deduplication, Error Semantics, and Fees 

### DIFF
--- a/standards/ICRC-1/ADVISORY.md
+++ b/standards/ICRC-1/ADVISORY.md
@@ -1,0 +1,58 @@
+# ICRC-1 Advisory
+
+This document provides clarifications and implementation guidance for the
+ICRC-1 standard.
+
+It focuses on error handling and atomicity for `icrc1_transfer`. This
+advisory is non-normative and does not change the ICRC-1 specification.
+
+
+## Error Semantics and Atomicity
+
+### Clarification
+
+The ICRC-1 specification defines error variants for `icrc1_transfer`, but
+does not explicitly state which ledger effects are guaranteed not to occur
+when an error is returned.
+
+This advisory clarifies the expected behavior.
+
+### Advisory Guidance
+
+Ledger implementations SHOULD ensure that `icrc1_transfer` is atomic with
+respect to **externally observable ledger effects**, including:
+
+- account balances, and
+- the transaction log.
+
+In particular:
+
+- A successful response (`Ok(nat)`) SHOULD imply that all balance updates and
+  the corresponding transaction log entry have been applied.
+
+- An error response SHOULD imply that:
+  - no account balances have been modified, and
+  - no transaction log entry corresponding to the call has been recorded.
+
+This guidance does not restrict changes to internal or auxiliary ledger
+state (e.g., caches, metrics, bookkeeping data).
+
+### Client Considerations
+
+- Clients MAY assume that an error response from `icrc1_transfer` implies no
+  externally observable ledger effects.
+- Clients SHOULD NOT assume stronger guarantees unless explicitly documented
+  by the ledger.
+
+## Scope and Non-Goals
+
+This advisory does not modify the ICRC-1 interface, define new error types, or
+constrain internal ledger state.
+
+
+## Summary
+
+ICRC-1 transfers are expected to be atomic with respect to balances and the
+transaction log, and error responses should not result in partial externally
+observable effects.
+

--- a/standards/ICRC-1/ADVISORY.md
+++ b/standards/ICRC-1/ADVISORY.md
@@ -1,7 +1,8 @@
 # ICRC-1 Advisory
 
-This document provides clarifications and implementation guidance for the
-ICRC-1 standard.
+The intent of this advisory is to provide additional clarification and
+explanation of certain behaviors described in the ICRC-1 specification, to
+help avoid potential misinterpretation in implementations.
 
 It focuses on error handling and atomicity for `icrc1_transfer`. This
 advisory is non-normative and does not change the ICRC-1 specification.
@@ -27,15 +28,17 @@ respect to **externally observable ledger effects**, including:
 
 In particular:
 
-- A successful response (`Ok(nat)`) SHOULD imply that all balance updates and
-  the corresponding transaction log entry have been applied.
+- A successful response (`Ok(nat)`) SHOULD imply that all balance updates related
+  to the transfer (including debits/credits for the transfer amount, fees, and
+  any other charges) and the corresponding transaction log entry have been
+  applied.
 
 - An error response SHOULD imply that:
-  - no account balances have been modified, and
+  - no account balances have been modified; and
   - no transaction log entry corresponding to the call has been recorded.
 
 This guidance does not restrict changes to internal or auxiliary ledger
-state (e.g., caches, metrics, bookkeeping data).
+state (e.g., caches, metrics, bookkeeping data, or internal logs).
 
 ### Client Considerations
 
@@ -53,6 +56,6 @@ constrain internal ledger state.
 ## Summary
 
 ICRC-1 transfers are expected to be atomic with respect to balances and the
-transaction log, and error responses should not result in partial externally
-observable effects.
+transaction log, and error responses SHOULD not result in any externally
+observable ledger effects.
 

--- a/standards/ICRC-2/ADVISORY.md
+++ b/standards/ICRC-2/ADVISORY.md
@@ -14,7 +14,7 @@ recommended practices.
 
 ### Clarification
 
-ICRC-2 methods (`approve` and `transfer_from`) include arguments and error
+ICRC-2 methods (`icrc2_approve` and `icrc2_transfer_from`) include arguments and error
 variants (`created_at_time`, `memo`, `Duplicate`, `TooOld`) that imply support
 for transaction deduplication and replay protection.
 
@@ -24,13 +24,13 @@ operations.
 ### Advisory Guidance
 
 Ledger implementations SHOULD implement transaction deduplication for
-`approve` and `transfer_from` according to the following rules:
+`icrc2_approve` and `icrc2_transfer_from` according to the following rules:
 
 #### Transaction Identity
 
 - A transaction is identified by the combination of:
   - the caller,
-  - the method name (`approve` or `transfer_from`),
+  - the method name (`icrc2_approve` or `icrc2_transfer_from`),
   - the full set of method arguments, including `created_at_time` and `memo`
     if provided.
 
@@ -66,7 +66,7 @@ Ledger implementations SHOULD implement transaction deduplication for
 
 #### Interaction with `expected_allowance`
 
-- For `approve`, the `expected_allowance` field provides an additional
+- For `icrc2_approve`, the `expected_allowance` field provides an additional
   conditional update mechanism.
 - `expected_allowance` does not replace transaction deduplication and SHOULD
   be evaluated only after deduplication checks have passed.
@@ -88,8 +88,8 @@ Ledger implementations SHOULD implement transaction deduplication for
 
 ### Clarification
 
-The ICRC-2 specification does not explicitly state that `approve` and
-`transfer_from` are atomic operations, nor does it clearly define which ledger
+The ICRC-2 specification does not explicitly state that `icrc2_approve` and
+`icrc2_transfer_from` are atomic operations, nor does it clearly define which ledger
 effects are guaranteed not to occur when an error is returned.
 
 With the exception of `AllowanceChanged`, which explicitly states that no
@@ -100,7 +100,7 @@ specified.
 
 To align with common ledger expectations and reduce ambiguity:
 
-- Ledger implementations SHOULD ensure that `approve` and `transfer_from`
+- Ledger implementations SHOULD ensure that `icrc2_approve` and `icrc2_transfer_from`
   operations are atomic with respect to **externally observable ledger
   effects**, such as:
   - account balances,
@@ -124,12 +124,12 @@ Additionally:
 - Client implementations SHOULD NOT assume stronger guarantees than those
   described above unless explicitly documented by the ledger.
 
-## 3. Fees for `approve` and `transfer_from`
+## 3. Fees for `icrc2_approve` and `icrc2_transfer_from`
 
 ### Clarification
 
 The ICRC-2 specification does not explicitly state the fees charged for
-`approve` or `transfer_from`.
+`icrc2_approve` or `icrc2_transfer_from`.
 
 This advisory clarifies that these operations are expected to be charged
 the same fee returned by the `icrc1_fee` method.
@@ -137,7 +137,7 @@ the same fee returned by the `icrc1_fee` method.
 ### Advisory Guidance
 
 - Ledger implementations SHOULD charge the fee returned by `icrc1_fee` for
-  both `approve` and `transfer_from`.
+  both `icrc2_approve` and `icrc2_transfer_from`.
 - Clients MAY assume that the applicable fee for ICRC-2 operations is the
   value returned by `icrc1_fee`.
 - Fees SHOULD only be charged when the operation succeeds.

--- a/standards/ICRC-2/ADVISORY.md
+++ b/standards/ICRC-2/ADVISORY.md
@@ -1,7 +1,7 @@
 # ICRC-2 Advisory
 
 This document provides clarifications and implementation guidance for the
-ICRC-2 standard based on findings from a security review.
+ICRC-2 standard.
 
 The intent of this advisory is to make explicit certain behaviors that are
 underspecified in the ICRC-2 specification, in order to reduce ambiguity for
@@ -9,7 +9,6 @@ ledger implementers and client developers. This document does not change the
 normative requirements of ICRC-2, but clarifies expectations and highlights
 recommended practices.
 
----
 
 ## 1. Transaction Deduplication
 

--- a/standards/ICRC-2/ADVISORY.md
+++ b/standards/ICRC-2/ADVISORY.md
@@ -55,3 +55,30 @@ Ledger implementations SHOULD implement transaction deduplication for
   transaction:
   - The ledger SHOULD reject the call and return a `Duplicate` error.
   - The ledger MUST NOT apply the transaction effects again.
+
+
+
+#### State Changes and Ordering
+
+- Deduplication checks SHOULD be performed before any externally observable
+  ledger effects are applied.
+- `Duplicate` or `TooOld` responses SHOULD imply that no balances, allowances,
+  or transaction log entries have been modified.
+
+#### Interaction with `expected_allowance`
+
+- For `approve`, the `expected_allowance` field provides an additional
+  conditional update mechanism.
+- `expected_allowance` does not replace transaction deduplication and SHOULD
+  be evaluated only after deduplication checks have passed.
+
+### Client Considerations
+
+- When transaction deduplication is implemented as described above,
+  **retrying an ICRC-2 call with identical parameters is safe** and will not
+  result in duplicated ledger effects.
+- Clients MAY rely on this behavior to safely retry requests in the presence
+  of timeouts, transient failures, or uncertain outcomes.
+- Clients SHOULD still be prepared to handle `Duplicate` and `TooOld` errors
+  and SHOULD avoid modifying parameters when retrying unless a new
+  transaction is intended.

--- a/standards/ICRC-2/ADVISORY.md
+++ b/standards/ICRC-2/ADVISORY.md
@@ -1,0 +1,57 @@
+# ICRC-2 Advisory
+
+This document provides clarifications and implementation guidance for the
+ICRC-2 standard based on findings from a security review.
+
+The intent of this advisory is to make explicit certain behaviors that are
+underspecified in the ICRC-2 specification, in order to reduce ambiguity for
+ledger implementers and client developers. This document does not change the
+normative requirements of ICRC-2, but clarifies expectations and highlights
+recommended practices.
+
+---
+
+## 1. Transaction Deduplication
+
+### Clarification
+
+ICRC-2 methods (`approve` and `transfer_from`) include arguments and error
+variants (`created_at_time`, `memo`, `Duplicate`, `TooOld`) that imply support
+for transaction deduplication and replay protection.
+
+This advisory clarifies the expected deduplication behavior for ICRC-2
+operations.
+
+### Advisory Guidance
+
+Ledger implementations SHOULD implement transaction deduplication for
+`approve` and `transfer_from` according to the following rules:
+
+#### Transaction Identity
+
+- A transaction is identified by the combination of:
+  - the caller,
+  - the method name (`approve` or `transfer_from`),
+  - the full set of method arguments, including `created_at_time` and `memo`
+    if provided.
+
+- Two calls with identical transaction identity are considered duplicates.
+
+#### Time Window
+
+- If `created_at_time` is provided:
+  - The ledger SHOULD reject calls whose `created_at_time` is too far in the
+    past or too far in the future relative to the ledger’s current time,
+    returning a `TooOld` error.
+  - The ledger SHOULD define and document the accepted time window.
+
+- If `created_at_time` is not provided:
+  - The ledger MAY treat each call as unique, or
+  - MAY apply ledger-specific policies; such behavior SHOULD be documented.
+
+#### Duplicate Handling
+
+- If a call is determined to be a duplicate of a previously processed
+  transaction:
+  - The ledger SHOULD reject the call and return a `Duplicate` error.
+  - The ledger MUST NOT apply the transaction effects again.

--- a/standards/ICRC-2/ADVISORY.md
+++ b/standards/ICRC-2/ADVISORY.md
@@ -41,8 +41,9 @@ Ledger implementations SHOULD implement transaction deduplication for
 - If `created_at_time` is provided:
   - The ledger SHOULD reject calls whose `created_at_time` is too far in the
     past or too far in the future relative to the ledger’s current time,
-    returning a `TooOld` error.
+    returning a `TooOld`/`CreatedInFuture` error.
   - The ledger SHOULD define and document the accepted time window.
+  - The ledger SHOULD NOT process duplicates.
 
 - If `created_at_time` is not provided:
   - The ledger MAY process duplicates, or
@@ -50,8 +51,7 @@ Ledger implementations SHOULD implement transaction deduplication for
 
 #### Duplicate Handling
 
-- If a call is determined to be a duplicate of a previously processed
-  transaction:
+- If duplicate transactions are not processed:
   - The ledger SHOULD reject the call and return a `Duplicate` error.
   - The ledger MUST NOT apply the transaction effects again.
 
@@ -61,7 +61,7 @@ Ledger implementations SHOULD implement transaction deduplication for
 
 - Deduplication checks SHOULD be performed before any externally observable
   ledger effects are applied.
-- `Duplicate` or `TooOld` responses SHOULD imply that no balances, allowances,
+- `Duplicate`, `TooOld` or `CreatedInFuture` responses SHOULD imply that no balances, allowances,
   or transaction log entries have been modified.
 
 #### Interaction with `expected_allowance`
@@ -73,12 +73,12 @@ Ledger implementations SHOULD implement transaction deduplication for
 
 ### Client Considerations
 
-- When transaction deduplication is implemented as described above,
+- When the ledger does not process duplicate transactions,
   **retrying an ICRC-2 call with identical parameters is safe** and will not
   result in duplicated ledger effects.
 - Clients MAY rely on this behavior to safely retry requests in the presence
   of timeouts, transient failures, or uncertain outcomes.
-- Clients SHOULD still be prepared to handle `Duplicate` and `TooOld` errors
+- Clients SHOULD still be prepared to handle `Duplicate`/`TooOld`/`CreatedInFuture` errors
   and SHOULD avoid modifying parameters when retrying unless a new
   transaction is intended.
 

--- a/standards/ICRC-2/ADVISORY.md
+++ b/standards/ICRC-2/ADVISORY.md
@@ -45,7 +45,7 @@ Ledger implementations SHOULD implement transaction deduplication for
   - The ledger SHOULD define and document the accepted time window.
 
 - If `created_at_time` is not provided:
-  - The ledger MAY treat each call as unique, or
+  - The ledger MAY process duplicates, or
   - MAY apply ledger-specific policies; such behavior SHOULD be documented.
 
 #### Duplicate Handling

--- a/standards/ICRC-2/ADVISORY.md
+++ b/standards/ICRC-2/ADVISORY.md
@@ -82,3 +82,47 @@ Ledger implementations SHOULD implement transaction deduplication for
 - Clients SHOULD still be prepared to handle `Duplicate` and `TooOld` errors
   and SHOULD avoid modifying parameters when retrying unless a new
   transaction is intended.
+
+
+
+## 2. Error Semantics and Atomicity
+
+### Clarification
+
+The ICRC-2 specification does not explicitly state that `approve` and
+`transfer_from` are atomic operations, nor does it clearly define which ledger
+effects are guaranteed not to occur when an error is returned.
+
+With the exception of `AllowanceChanged`, which explicitly states that no
+allowance update has occurred, the semantics of other error variants are not
+specified.
+
+### Advisory Guidance
+
+To align with common ledger expectations and reduce ambiguity:
+
+- Ledger implementations SHOULD ensure that `approve` and `transfer_from`
+  operations are atomic with respect to **externally observable ledger
+  effects**, such as:
+  - account balances,
+  - allowances,
+  - and the transaction log.
+
+- If an ICRC-2 method successfully applies such effects, the ledger SHOULD
+  return a success response (`Ok(nat)`).
+
+- If an error response is returned, the ledger SHOULD ensure that:
+  - no balances or allowances have been modified, and
+  - no transaction log entry corresponding to the call has been recorded.
+
+This guidance does not restrict ledgers from mutating internal or auxiliary
+state (e.g., caches, metrics, rate limits, or bookkeeping data) when handling
+a call that results in an error.
+
+Additionally:
+
+- Ledger implementations SHOULD document the meaning of each error variant.
+- Client implementations SHOULD NOT assume stronger guarantees than those
+  described above unless explicitly documented by the ledger.
+
+

--- a/standards/ICRC-2/ADVISORY.md
+++ b/standards/ICRC-2/ADVISORY.md
@@ -1,14 +1,13 @@
 # ICRC-2 Advisory
 
-This document provides clarifications and implementation guidance for the
-ICRC-2 standard.
+The intent of this advisory is to provide additional clarification and
+explanation of certain behaviors described in the ICRC-2 specification, to
+help avoid potential misinterpretation in implementations.
 
-The intent of this advisory is to make explicit certain behaviors that are
-underspecified in the ICRC-2 specification, in order to reduce ambiguity for
-ledger implementers and client developers. This document does not change the
-normative requirements of ICRC-2, but clarifies expectations and highlights
-recommended practices.
-
+It clarifies expectations and the intended meaning, and highlights recommended
+practices for transaction deduplication, error semantics and atomicity, and fee
+handling for `icrc2_approve` and `icrc2_transfer_from`. This advisory is
+non-normative and does not change the ICRC-2 specification.
 
 ## 1. Transaction Deduplication
 
@@ -28,9 +27,9 @@ Ledger implementations SHOULD implement transaction deduplication for
 
 #### Transaction Identity
 
-- A transaction is identified by the combination of:
-  - the caller,
-  - the method name (`icrc2_approve` or `icrc2_transfer_from`),
+- A transaction is identified by its transaction identity, which is the combination of:
+  - the caller;
+  - the method name (`icrc2_approve` or `icrc2_transfer_from`); and
   - the full set of method arguments, including `created_at_time` and `memo`
     if provided.
 
@@ -54,8 +53,6 @@ Ledger implementations SHOULD implement transaction deduplication for
 - If duplicate transactions are not processed:
   - The ledger SHOULD reject the call and return a `Duplicate` error.
   - The ledger MUST NOT apply the transaction effects again.
-
-
 
 #### State Changes and Ordering
 
@@ -82,8 +79,6 @@ Ledger implementations SHOULD implement transaction deduplication for
   and SHOULD avoid modifying parameters when retrying unless a new
   transaction is intended.
 
-
-
 ## 2. Error Semantics and Atomicity
 
 ### Clarification
@@ -102,17 +97,16 @@ To align with common ledger expectations and reduce ambiguity:
 
 - Ledger implementations SHOULD ensure that `icrc2_approve` and `icrc2_transfer_from`
   operations are atomic with respect to **externally observable ledger
-  effects**, such as:
-  - account balances,
-  - allowances,
-  - and the transaction log.
+  effects**, including:
+  - account balances;
+  - allowances; and
+  - the transaction log.
 
 - If an ICRC-2 method successfully applies such effects, the ledger SHOULD
   return a success response (`Ok(nat)`).
 
-- If an error response is returned, the ledger SHOULD ensure that:
-  - no balances or allowances have been modified, and
-  - no transaction log entry corresponding to the call has been recorded.
+- If an error response is returned, the ledger SHOULD ensure that no externally
+  observable ledger effects have occurred.
 
 This guidance does not restrict ledgers from mutating internal or auxiliary
 state (e.g., caches, metrics, rate limits, or bookkeeping data) when handling
@@ -142,4 +136,19 @@ the same fee returned by the `icrc1_fee` method.
   value returned by `icrc1_fee`.
 - Fees SHOULD only be charged when the operation succeeds.
 - The fee SHOULD be applied in a manner consistent with ICRC-1 transfers.
+
+## Summary
+
+ICRC-2 ledgers are expected to support transaction deduplication for
+`icrc2_approve` and `icrc2_transfer_from` when `created_at_time` is provided,
+to ensure that retries with identical parameters do not result in duplicated
+externally observable ledger effects.
+
+`icrc2_approve` and `icrc2_transfer_from` are expected to be atomic with
+respect to externally observable ledger effects (balances, allowances, and the
+transaction log). Error responses should imply that no externally observable
+ledger effects have occurred.
+
+ICRC-2 operations are expected to be charged the same fee returned by
+`icrc1_fee`, and fees should only be charged when the operation succeeds.
 

--- a/standards/ICRC-2/ADVISORY.md
+++ b/standards/ICRC-2/ADVISORY.md
@@ -125,4 +125,22 @@ Additionally:
 - Client implementations SHOULD NOT assume stronger guarantees than those
   described above unless explicitly documented by the ledger.
 
+## 3. Fees for `approve` and `transfer_from`
+
+### Clarification
+
+The ICRC-2 specification does not explicitly state the fees charged for
+`approve` or `transfer_from`.
+
+This advisory clarifies that these operations are expected to be charged
+the same fee returned by the `icrc1_fee` method.
+
+### Advisory Guidance
+
+- Ledger implementations SHOULD charge the fee returned by `icrc1_fee` for
+  both `approve` and `transfer_from`.
+- Clients MAY assume that the applicable fee for ICRC-2 operations is the
+  value returned by `icrc1_fee`.
+- Fees SHOULD only be charged when the operation succeeds.
+- The fee SHOULD be applied in a manner consistent with ICRC-1 transfers.
 


### PR DESCRIPTION
### Add ICRC-1, ICRC-2 Advisory Clarifying Deduplication, Error Semantics, and Fees

This PR adds an `ADVISORY.md` document next to `standards/ICRC-2/README.md` to clarify several aspects of the ICRC-2 standard that were previously underspecified, and raised within a security review.

The advisory is non-normative and does not change the ICRC-2 interface or compliance requirements. Its purpose is to reduce ambiguity for ledger implementers and client developers by making certain expectations explicit.

Specifically, the advisory clarifies:
- Transaction deduplication for `approve` and `transfer_from`, including that retrying calls with identical parameters is safe when deduplication is implemented -- [SECFIND-1088](https://dfinity.atlassian.net/browse/SECFIND-1088) 
- Error semantics and atomicity, limited to externally observable ledger effects (balances, allowances, transaction log) -- [SECFIND-1089](https://dfinity.atlassian.net/browse/SECFIND-1089) 
- Fees for ICRC-2 operations, specifying that `approve` and `transfer_from` are expected to charge the fee returned by `icrc1_fee` -- [SECFIND-1090](https://dfinity.atlassian.net/browse/SECFIND-1090) 

The advisory documents common expectations and best practices without retroactively invalidating existing implementations.


[SECFIND-1088]: https://dfinity.atlassian.net/browse/SECFIND-1088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SECFIND-1089]: https://dfinity.atlassian.net/browse/SECFIND-1089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SECFIND-1090]: https://dfinity.atlassian.net/browse/SECFIND-1090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ