### PR TITLE
chore: rename @dfinity/defi-team to @dfinity/defi in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@dfinity/defi-team
+@dfinity/defi


### PR DESCRIPTION
## Summary

- The `@dfinity/defi-team` GitHub team has been renamed to `@dfinity/defi`. This PR updates `.github/CODEOWNERS` to reflect the new team name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)